### PR TITLE
feat(tldts): use tldts to handle our url parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 CHANGELOG.md
 ============
+
+WIP
+-----
+* Add tldts to handle our public suffix and way more
+
 3.0.0
 ------
 * Added `gob` to multiextensions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,340 @@
+{
+  "name": "@dashlane/simple-url-parser",
+  "version": "3.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/mocha": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.6.tgz",
+      "integrity": "sha512-1axi39YdtBI7z957vdqXI4Ac25e7YihYQtJa+Clnxg1zTJEaIRbndt71O3sP4GAMgiAm0pY26/b9BrY4MR/PMw==",
+      "dev": true
+    },
+    "@types/should": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@types/should/-/should-13.0.0.tgz",
+      "integrity": "sha512-Mi6YZ2ABnnGGFMuiBDP0a8s1ZDCDNHqP97UH8TyDmCWuGGavpsFMfJnAMYaaqmDlSCOCNbVLHBrSDEOpx/oLhw==",
+      "dev": true,
+      "requires": {
+        "should": "*"
+      }
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "make-error": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "should": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+      "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
+      "dev": true,
+      "requires": {
+        "should-equal": "^2.0.0",
+        "should-format": "^3.0.3",
+        "should-type": "^1.4.0",
+        "should-type-adaptors": "^1.0.1",
+        "should-util": "^1.0.0"
+      }
+    },
+    "should-equal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+      "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
+      "dev": true,
+      "requires": {
+        "should-type": "^1.4.0"
+      }
+    },
+    "should-format": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+      "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
+      "dev": true,
+      "requires": {
+        "should-type": "^1.3.0",
+        "should-type-adaptors": "^1.0.1"
+      }
+    },
+    "should-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+      "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=",
+      "dev": true
+    },
+    "should-type-adaptors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+      "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+      "dev": true,
+      "requires": {
+        "should-type": "^1.3.0",
+        "should-util": "^1.0.0"
+      }
+    },
+    "should-util": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.0.tgz",
+      "integrity": "sha1-yYzaN0qmsZDfi6h8mInCtNtiAGM=",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
+      "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "tldts": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-4.0.2.tgz",
+      "integrity": "sha512-Et17MG0EGhO71VLqoP3fLw1sFHNeyoizCEFTFKeLOrLXmuWIYgcuDehfiQcXcs+z5bcA9PGjtR3ZUE8wdLRSdg=="
+    },
+    "ts-node": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
+      "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.0",
+        "buffer-from": "^1.1.0",
+        "diff": "^3.1.0",
+        "make-error": "^1.1.1",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.5.6",
+        "yn": "^2.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "typescript": {
+      "version": "3.3.3333",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
+      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "yn": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "url": "https://github.com/Dashlane/url-parser/issues"
   },
   "homepage": "https://github.com/Dashlane/url-parser#readme",
-  "dependencies": {},
+  "dependencies": {
+    "tldts": "^4.0.2"
+  },
   "keywords": [
     "url-parser",
     "url",

--- a/ts/lib/url-parser.test.ts
+++ b/ts/lib/url-parser.test.ts
@@ -105,10 +105,14 @@ describe('UrlUtils', () => {
         });
 
         it('should extract the domain when it has multi-extensions', () => {
-            const url1 = 'www.domain3.judiciary.uk';
-            UrlUtils.extractRootDomain(url1).should.eql('domain3.judiciary.uk');
+            const url1 = 'www.domain3.gov.uk';
+            UrlUtils.extractRootDomain(url1).should.eql('domain3.gov.uk');
             const url2 = 'www.domain3.qc.ca';
             UrlUtils.extractRootDomain(url2).should.eql('domain3.qc.ca');
+            const url3 = 'www.city.takayama.gifu.jp';
+            UrlUtils.extractRootDomain(url3).should.eql('city.takayama.gifu.jp');
+            const url4 = 'https://www.impots.gouv.fr';
+            UrlUtils.extractRootDomain(url4).should.eql('impots.gouv.fr');
         });
 
     });
@@ -130,6 +134,15 @@ describe('UrlUtils', () => {
         it('should extract the domain name when there is no trailing path', () => {
             const url = 'http://www.google.com';
             UrlUtils.extractRootDomainName(url).should.eql('google');
+        });
+
+        it('should extract the domain name when it has multi-extensions', () => {
+            const url1 = 'www.domain3.gov.uk';
+            UrlUtils.extractRootDomainName(url1).should.eql('domain3');
+            const url2 = 'www.city.takayama.gifu.jp';
+            UrlUtils.extractRootDomainName(url2).should.eql('city');
+            const url3 = 'https://www.impots.gouv.fr';
+            UrlUtils.extractRootDomainName(url3).should.eql('impots');
         });
 
     });
@@ -164,9 +177,14 @@ describe('UrlUtils', () => {
         it('should extract the full domain but discard the port', () => {
             const url = 'http://parml20.dashlane.com:8000/login_std.html';
             UrlUtils.extractFullDomain(url).should.eql('parml20.dashlane.com');
-
         });
 
+        it('should extract the full domain name when it has multi-extensions', () => {
+            const url1 = 'www.city.takayama.gifu.jp';
+            UrlUtils.extractFullDomain(url1).should.eql('www.city.takayama.gifu.jp');
+            const url2 = 'https://www.impots.gouv.fr';
+            UrlUtils.extractFullDomain(url2).should.eql('www.impots.gouv.fr');
+        });
     });
 
     describe('extractSubDomainName', () => {
@@ -255,18 +273,18 @@ describe('UrlUtils', () => {
             const url = 'http://[1080:0:0:0:8:800:200C:417A]:8000/index.html';
             const parsedUrl = UrlUtils.getParsedUrl(url);
             parsedUrl.url.should.eql(url);
-            parsedUrl.fullDomain.should.eql('[1080:0:0:0:8:800:200C:417A]');
-            parsedUrl.rootDomain.should.eql('[1080:0:0:0:8:800:200C:417A]');
-            parsedUrl.rootDomainName.should.eql('[1080:0:0:0:8:800:200C:417A]');
+            parsedUrl.fullDomain.should.eql('1080:0:0:0:8:800:200c:417a');
+            parsedUrl.rootDomain.should.eql('1080:0:0:0:8:800:200c:417a');
+            parsedUrl.rootDomainName.should.eql('1080:0:0:0:8:800:200c:417a');
         });
 
         it('should correctly parse an IPv6-based url', () => {
             const url = 'http://[1080:0:0:0:8:800:200C:417A]/index.html';
             const parsedUrl = UrlUtils.getParsedUrl(url);
             parsedUrl.url.should.eql(url);
-            parsedUrl.fullDomain.should.eql('[1080:0:0:0:8:800:200C:417A]');
-            parsedUrl.rootDomain.should.eql('[1080:0:0:0:8:800:200C:417A]');
-            parsedUrl.rootDomainName.should.eql('[1080:0:0:0:8:800:200C:417A]');
+            parsedUrl.fullDomain.should.eql('1080:0:0:0:8:800:200c:417a');
+            parsedUrl.rootDomain.should.eql('1080:0:0:0:8:800:200c:417a');
+            parsedUrl.rootDomainName.should.eql('1080:0:0:0:8:800:200c:417a');
         });
     });
 

--- a/ts/lib/url-parser.ts
+++ b/ts/lib/url-parser.ts
@@ -1,3 +1,4 @@
+import { parse } from 'tldts';
 
 const protocols: string[] = [
     'http://',
@@ -8,78 +9,29 @@ const protocols: string[] = [
     'smb://'
 ];
 
-const multiExtensionsPrefix: string[] = [
-    'co',
-    'com',
-    'fr',
-    'ac',
-    'gov',
-    'org',
-    'edu',
-    'net',
-    'gob',
-];
-
-const multiExtensions: string[] = [
-    // UK multi-extensions
-    'judiciary.uk',
-    'ltd.uk',
-    'me.uk',
-    'mod.uk',
-    'nhs.uk',
-    'nic.uk',
-    'parliament.uk',
-    'plc.uk',
-    'sch.uk',
-    'bl.uk',
-    'jet.uk',
-    'british-library.uk',
-    'nls.uk',
-
-    // Canadian provincial domains
-    // https://en.wikipedia.org/wiki/.ca#Third-level_.28provincial.29_and_fourth-level_.28municipal.29_domains
-    'ab.ca',
-    'bc.ca',
-    'mb.ca',
-    'nb.ca',
-    'nf.ca',
-    'nl.ca',
-    'ns.ca',
-    'nt.ca',
-    'nu.ca',
-    'on.ca',
-    'pe.ca',
-    'qc.ca',
-    'sk.ca',
-    'yk.ca',
-];
-
-function domainIsIPv4(domainParts: string[]): boolean {
-    // ex with url = 'http://54.77.248.115.google.com'
-    // domainParts = [ '54', '77', '248', '115', 'google', 'com' ]
-    // => not an IP
-    if (isNaN(parseInt(domainParts[domainParts.length - 1], 10))) {
+function domainIsIPv4(hostname: string): boolean {
+    // ex with an url http://54.77.248.115.google.com
+    // hostname 54.77.248.115
+    const hostnameParts = hostname.split('.');
+    if (isNaN(parseInt(hostnameParts[hostnameParts.length - 1], 10))) {
         return false;
     } else {
         // ensure valid IP format (basic test)
-        return (domainParts.length === 4) && domainParts.every( (domainPart: string) => {
+        return (hostnameParts.length === 4) && hostnameParts.every( (domainPart: string) => {
             const byte = parseInt(domainPart, 10);
             return !isNaN(byte) && byte <= 255;
         });
     }
 }
 
-function domainIsIPv6(domainParts: string[]): boolean {
-    // ex with url = 'http://[1080:0:0:0:8:800:200C:417A]'
-    // domainParts = [ '[1080:0:0:0:8:800:200C:417A]' ]
-    var ipv6 = domainParts[0];
-    const checkFormat = domainParts.length === 1 &&
-           ipv6[0] === '[' &&
-           ipv6[ ipv6.length - 1] === ']' &&
-           ipv6.split(':').length >= 4 &&   // [2001:db8::1] is a valid IPv6 address and equal to [2001:db8:0:1:0:0:0:0]
-           ipv6.split(':').length <= 8;
+function domainIsIPv6(hostname: string): boolean {
+    // ex with an url http://[1080:0:0:0:8:800:200C:417A]
+    // hostname 1080:0:0:0:8:800:200C:417A
+    const hostnameParts = hostname.split(':');
+    const checkFormat = hostnameParts.length >= 4 &&   // [2001:db8::1] is a valid IPv6 address and equal to [2001:db8:0:1:0:0:0:0]
+           hostnameParts.length <= 8;
 
-    const checkBytes = ipv6.slice(1, ipv6.length-1).split(':').every( (str: string) => {
+    const checkBytes = hostnameParts.every( (str: string) => {
         if (!str) {
             // In IPv6 protocol, this is a valid IPv6 address: [1080::::8:800:200C:417A]
             str = '0';
@@ -91,8 +43,9 @@ function domainIsIPv6(domainParts: string[]): boolean {
     return checkFormat && checkBytes;
 }
 
-function domainIsIP(domainParts: string[]): boolean {
-    return domainIsIPv4(domainParts) || domainIsIPv6(domainParts);
+function domainIsIP(url: string): boolean {
+    const hostname = parse(url).hostname;
+    return domainIsIPv4(hostname) || domainIsIPv6(hostname);
 }
 
 export function extractFilepathFromUrl(url: string): string {
@@ -119,74 +72,44 @@ export function extractFullFilepathFromUrl(url: string): string {
 }
 
 export function extractFullDomain(url: string): string {
-    let ret: string = url;
-
-    // Strip the protocol
-    for (let i = 0; i < protocols.length; i++) {
-        const p = protocols[i];
-        if (url.indexOf(p) === 0) {
-            ret = url.slice(p.length);
-            break;
+    const parsedUrl = parse(url);
+    if (domainIsIP(parsedUrl.hostname)) {
+        return parsedUrl.hostname;
+    } else {
+        if(parsedUrl.subdomain) {
+            return `${parsedUrl.subdomain}.${parsedUrl.domain}`
+        } else {
+            return parsedUrl.domain;
         }
     }
-
-    // Strip trailing path
-    const idx: number = ret.indexOf('/');
-    if (idx !== -1) {
-        ret = ret.slice(0, idx);
-    }
-
-    // Strip port safely (avoid collision with ipv6)
-    const splitBySemicolon = ret.split(':');
-    const portCandidate = splitBySemicolon[ splitBySemicolon.length - 1 ];
-    if (portCandidate.match(/^[0-9]+$/)) {
-        splitBySemicolon.pop(); // remove port
-        ret = splitBySemicolon.join(':');
-    }
-
-    return ret;
 }
 
 export function extractRootDomain(url: string): string {
-    const domain: string = extractFullDomain(url);
-
-    let domainParts: string[] = domain.split('.');
-
-    if (domainIsIP(domainParts)) {
-        return domainParts.join('.');
-    }
-
-    if (domainParts.length <= 2) {
-        return domain;
-    } else if (multiExtensionsPrefix.indexOf(domainParts[domainParts.length - 2]) !== -1) {
-        domainParts = domainParts.slice(domainParts.length - 3);
-    } else if (multiExtensions.indexOf(domainParts.slice(domainParts.length - 2).join('.')) !== -1) {
-        domainParts = domainParts.slice(domainParts.length - 3);
+    const parsedUrl = parse(url);
+    if (domainIsIP(parsedUrl.hostname)) {
+        return parsedUrl.hostname;
     } else {
-        domainParts = domainParts.slice(domainParts.length - 2);
+        return parsedUrl.domain;
     }
-    return domainParts.join('.');
 }
 
 export function extractRootDomainName(url: string): string {
-    const rootDomain: string = extractRootDomain(url);
-    const domainParts: string[] = rootDomain.split('.');
-
-    if (domainIsIP(domainParts)) {
-        return rootDomain;
+    const parsedUrl = parse(url);
+    if (domainIsIP(parsedUrl.hostname)) {
+        return parsedUrl.hostname;
     } else {
-        return domainParts[0];
+        return parsedUrl.domain.substring(0, parsedUrl.domain.indexOf(`.${parsedUrl.publicSuffix}`));
     }
 }
 
 export function extractSubDomainName(url: string): string {
-    const subDomainName = extractFullDomain(url)
-        .replace(extractRootDomain(url), '')
-        .replace(/\.$/, '');
-    if (!subDomainName || subDomainName === 'www') {
+    const parsedUrl = parse(url);
+    const subdomain = parsedUrl.subdomain;
+
+    if (!subdomain || subdomain === 'www') {
         return null;
     }
-    return subDomainName;
+    return subdomain;
 }
 
 export interface ParsedUrl {
@@ -208,21 +131,19 @@ export function getParsedUrl(url: string): ParsedUrl {
 }
 
 export function isUrlWithIPv4(url: string): boolean {
-    const domain: string = extractFullDomain(url);
-    let domainParts: string[] = domain.split('.');
-    return domainIsIPv4(domainParts);
+    const { hostname } = parse(url);
+    return domainIsIPv4(hostname);
 }
 
 export function isUrlWithIPv6(url: string): boolean {
-    const domain: string = extractFullDomain(url);
-    let domainParts: string[] = domain.split('.');
-    return domainIsIPv6(domainParts);
+    const { hostname } = parse(url);
+    return domainIsIPv6(hostname);
 }
 
+
 export function isUrlWithIP(url: string): boolean {
-    const domain: string = extractFullDomain(url);
-    let domainParts: string[] = domain.split('.');
-    return domainIsIP(domainParts);
+    const { hostname } = parse(url);
+    return domainIsIP(hostname);
 }
 
 export function isUrlWithDomain(url: string): boolean {


### PR DESCRIPTION
https://publicsuffix.org/learn/

We have one big change is our lib, regarding the ipv6:

Previously parsing this URL `http://[1080:0:0:0:8:800:200C:417A]:8000/index.html`
would have returned `[1080:0:0:0:8:800:200C:417A]` as `fullDomain`, `rootDomain` and `rootDomainName`
Now it returns `1080:0:0:0:8:800:200c:417a` no bracket and letter are in lowerCase.