### PR TITLE
Feat/parse url without extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 CHANGELOG.md
 ============
+3.5.0
+-----
+* Add support for url without extension
 
-WIP
+3.4.0
 -----
 * Add additional validations for a secure URL : `urlContainsProtocol`, `omitCredentialsFromUrl` and `omitQueryStringFromUrl` 
 * Improve `isUrl`

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,11 +7,12 @@ Publishing a new version
 -------------------------
 
 
-### Before merging into master
+### 1- Update the CHANGELOG.md
 
-Please update `CHANGELOG.md` by write changes introduced.
+The `CHANGELOG.md` is not automatically updated.
+You need to manually rename the WIP section into the version you are going to release. 
 
-### After merging into master
+### 2- Create the release
 
 Once your Pull Request has been merged, you can pull the latest `master` on your machine
 and run `npm version major|minor|patch`.
@@ -22,6 +23,8 @@ and run `npm version major|minor|patch`.
 
 
 Running this npm task will bump the `package.json` version and create `git` tag.
+
+### 3- Push and publish the release
 
 Then you can push and publish the update :
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "TS_NODE_COMPILER_OPTIONS='{\"target\":\"es6\"}' mocha -r ts-node/register ts/**/*.test.ts",
     "test-watch": "npm test -- --watch-extensions ts --watch",
     "ci": "npm test && npm audit",
-    "prepublish": "npm build && npm test"
+    "prepublish": "npm run build && npm test"
   },
   "repository": {
     "type": "git",

--- a/ts/lib/url-parser.test.ts
+++ b/ts/lib/url-parser.test.ts
@@ -307,16 +307,6 @@ describe('UrlUtils', () => {
 
     describe('getParsedUrl', () => {
 
-        it('should not throw when provided with an url without an extension', () => {
-            const url = 'http://notvalid';
-            const parsedUrl = UrlUtils.getParsedUrl(url);
-            parsedUrl.url.should.eql(url);
-            (parsedUrl.fullDomain === null).should.be.True();
-            (parsedUrl.rootDomain === null).should.be.True();
-            (parsedUrl.rootDomainName === null).should.be.True();
-            (parsedUrl.urlHash === null).should.be.True();
-        });
-
         it('should correctly parse an url', () => {
             const url = 'https://s3-eu-west-1.amazonaws.com/dashlane-static-resources/webTesting/signin_prompt.html';
             const parsedUrl = UrlUtils.getParsedUrl(url);
@@ -324,6 +314,18 @@ describe('UrlUtils', () => {
             parsedUrl.fullDomain.should.eql('s3-eu-west-1.amazonaws.com');
             parsedUrl.rootDomain.should.eql('amazonaws.com');
             parsedUrl.rootDomainName.should.eql('amazonaws');
+            (parsedUrl.urlHash === null).should.be.True();
+        });
+
+        it('should correctly parse an url without an extension', () => {
+            const url = 'http://url-without-extension/login';
+            const parsedUrl = UrlUtils.getParsedUrl(url);
+            console.log('get Parsed URL output:');
+            console.log(parsedUrl);
+            parsedUrl.url.should.eql(url);
+            parsedUrl.fullDomain.should.eql('url-without-extension');
+            parsedUrl.rootDomain.should.eql('url-without-extension');
+            parsedUrl.rootDomainName.should.eql('url-without-extension');
             (parsedUrl.urlHash === null).should.be.True();
         });
 

--- a/ts/lib/url-parser.test.ts
+++ b/ts/lib/url-parser.test.ts
@@ -16,7 +16,7 @@ describe('UrlUtils', () => {
             UrlUtils.extractFilepathFromUrl(url).should.eql('/a/b/c/url/lol.png');
         });
 
-        it('should correctly replace all known protocols', () => {
+        it('should correctly extract the file path with known protocols', () => {
             const base = '/my/toto/images/latete.jpg';
             const domain = 'toto.com';
             UrlUtils.extractFilepathFromUrl(`http://${domain}${base}`).should.eql(base);
@@ -27,7 +27,7 @@ describe('UrlUtils', () => {
             UrlUtils.extractFilepathFromUrl(`smb://${domain}${base}`).should.eql(base);
         });
 
-        it('should not do anything to urls with unknown protocols', () => {
+        it('should return the whole urls with unknown protocols', () => {
             const url = 'toto.com/my/toto/images/latete.jpg';
             UrlUtils.extractFilepathFromUrl(`unmht://${url}`).should.eql(`unmht://${url}`);
             UrlUtils.extractFilepathFromUrl(`toto://${url}`).should.eql(`toto://${url}`);

--- a/ts/lib/url-parser.ts
+++ b/ts/lib/url-parser.ts
@@ -91,13 +91,23 @@ export function extractFullDomain(url: string): string {
 
     if (domainIsIP(parsedUrl.hostname) || parsedUrl.hostname === 'localhost') {
         return parsedUrl.hostname;
-    } else {
-        if (parsedUrl.subdomain) {
-            return `${parsedUrl.subdomain}.${parsedUrl.domain}`
-        } else {
-            return parsedUrl.domain;
-        }
     }
+    if (parsedUrl.subdomain) {
+        return `${parsedUrl.subdomain}.${parsedUrl.domain}`
+    }
+    if (parsedUrl.domain) {
+        return parsedUrl.domain;
+    }
+
+    // If none of the cases above allowed to return,
+    // then we are trying to parse an url that is not supported by tldts (ex. http://url-without-extension)
+    // let's use the URL api to parse it
+    const parsedUrlWithUrlApi = new URL(url);
+    if (parsedUrlWithUrlApi.hostname) {
+        return parsedUrlWithUrlApi.hostname
+    }
+
+    return null;
 }
 
 export function extractNakedDomain(url: string): string {
@@ -115,9 +125,19 @@ export function extractRootDomain(url: string): string {
     const parsedUrl = parse(url);
     if (domainIsIP(parsedUrl.hostname) || parsedUrl.hostname === 'localhost') {
         return parsedUrl.hostname;
-    } else {
+    }
+    if (parsedUrl.domain) {
         return parsedUrl.domain;
     }
+
+    // If none of the cases above allowed to return,
+    // then we may be trying to parse an url that is not supported by tldts (ex. http://url-without-extension)
+    // let's use the URL api to parse it
+    const parsedUrlWithUrlApi = new URL(url);
+    if (parsedUrlWithUrlApi.hostname) {
+        return parsedUrlWithUrlApi.hostname
+    }
+    return null;
 }
 
 export function extractRootDomainName(url: string): string {
@@ -127,11 +147,23 @@ export function extractRootDomainName(url: string): string {
     const parsedUrl = parse(url);
     if (domainIsIP(parsedUrl.hostname) || parsedUrl.hostname === 'localhost') {
         return parsedUrl.hostname;
-    } else {
-        return (parsedUrl.publicSuffix && parsedUrl.domain) ?
-            parsedUrl.domain.substring(0, parsedUrl.domain.indexOf(`.${parsedUrl.publicSuffix}`)) :
-            parsedUrl.domain;
     }
+    if (parsedUrl.domain) {
+        if (parsedUrl.publicSuffix) {
+            return parsedUrl.domain.substring(0, parsedUrl.domain.indexOf(`.${parsedUrl.publicSuffix}`));
+        }
+        return parsedUrl.domain;
+    }
+
+    // If none of the cases above allowed to return,
+    // then we are trying to parse an url that is not supported by tldts (ex. http://url-without-extension)
+    // let's use the URL api to parse it
+    const parsedUrlWithUrlApi = new URL(url);
+    if (parsedUrlWithUrlApi.hostname) {
+        return parsedUrlWithUrlApi.hostname;
+    }
+
+    return null;
 }
 
 export function extractSubDomainName(url: string): string {


### PR DESCRIPTION
Let's allow url-parser to parse urls without extension.
For example calling getParsedUrl on an url like "http://smallurl" should return "smallurl" as fullDomain, rootDomain and rootDomainName (prior to this MR it is returning null for all of them)
Since tldts is not parsing this kind of urls, I used the URL api as a fallback when the parsing with tldts fails.
